### PR TITLE
Enhance Config for granular alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ handler:
     url: ""
   webhook:
     url: ""
+
+// Resource Config Section for generic alerting
 resource:
   deployment: false
   replicationcontroller: false
@@ -283,6 +285,19 @@ resource:
   secret: false
   configmap: false
   ingress: false
+
+// Events Config Section for granular alerting
+event:
+    global:
+     - pod
+     - deployment
+    create:
+     - service
+    update:
+
+    delete:
+     - job
+     - service
 namespace: ""
 
 ```
@@ -360,6 +375,31 @@ $ kubewatch resource add --rc --po --svc
 
 # rc, po and svc will be stoped from being watched
 $ kubewatch resource remove --rc --po --svc
+```
+
+## Events
+
+Event config section in `.kubewatch.yaml` file can be used for granular alerting.
+
+```
+handler:
+  slack:
+    token: xoxb-xxxxx-yyyyyyy
+    channel: kube-watch-test
+
+event:
+    global:                       // global alerts for all events
+     - pod
+     - deployment
+    create:                       // create alerts for resource object creation
+     - service
+    update:                       // update alerts for resource object updation
+     - 
+    delete:                       // delete alerts for resource object deletion
+     - job
+     - service
+
+namespace: ""
 ```
 
 # Build

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -83,7 +83,7 @@ func configureResource(operation string, cmd *cobra.Command, conf *config.Config
 	}{
 		{
 			"svc",
-			&conf.Resource.Services,
+			&conf.Resource.Service,
 		},
 		{
 			"deploy",
@@ -161,7 +161,7 @@ func init() {
 		resourceConfigRemoveCmd,
 	)
 	// Add resource object flags as PersistentFlags to resourceConfigCmd
-	resourceConfigCmd.PersistentFlags().Bool("svc", false, "watch for services")
+	resourceConfigCmd.PersistentFlags().Bool("svc", false, "watch for Service")
 	resourceConfigCmd.PersistentFlags().Bool("deploy", false, "watch for deployments")
 	resourceConfigCmd.PersistentFlags().Bool("po", false, "watch for pods")
 	resourceConfigCmd.PersistentFlags().Bool("rc", false, "watch for replication controllers")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ supported webhooks:
 			logrus.Fatal(err)
 		}
 		config.CheckMissingResourceEnvvars()
+		config.UnmarshallConfig()
 		c.Run(config)
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/Sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -44,7 +45,7 @@ type Resource struct {
 	ReplicationController bool `json:"rc"`
 	ReplicaSet            bool `json:"rs"`
 	DaemonSet             bool `json:"ds"`
-	Services              bool `json:"svc"`
+	Service              bool `json:"svc"`
 	Pod                   bool `json:"po"`
 	Job                   bool `json:"job"`
 	PersistentVolume      bool `json:"pv"`
@@ -54,13 +55,22 @@ type Resource struct {
 	Ingress               bool `json:"ing"`
 }
 
+// Event struct for granular config
+type Event struct {
+	Global []string `json:"string,omitempty"`
+	Create []string `json:"create,omitempty"`
+	Update []string `json:"update,omitempty"`
+	Delete []string `json:"delete,omitempty"`
+}
+
 // Config struct contains kubewatch configuration
 type Config struct {
 	Handler Handler `json:"handler"`
 	//Reason   []string `json:"reason"`
-	Resource Resource `json:"resource"`
+	Resource Resource `json:"resource,omitempty"`
 	// for watching specific namespace, leave it empty for watching all.
 	// this config is ignored when watching namespaces
+	Event     Event  `json:"event,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 }
 
@@ -153,6 +163,7 @@ func (c *Config) Load() error {
 
 // CheckMissingResourceEnvvars will read the environment for equivalent config variables to set
 func (c *Config) CheckMissingResourceEnvvars() {
+
 	if !c.Resource.DaemonSet && os.Getenv("KW_DAEMONSET") == "true" {
 		c.Resource.DaemonSet = true
 	}
@@ -171,8 +182,8 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	if !c.Resource.ReplicationController && os.Getenv("KW_REPLICATION_CONTROLLER") == "true" {
 		c.Resource.ReplicationController = true
 	}
-	if !c.Resource.Services && os.Getenv("KW_SERVICE") == "true" {
-		c.Resource.Services = true
+	if !c.Resource.Service && os.Getenv("KW_SERVICE") == "true" {
+		c.Resource.Service = true
 	}
 	if !c.Resource.Job && os.Getenv("KW_JOB") == "true" {
 		c.Resource.Job = true
@@ -194,6 +205,112 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	}
 	if (c.Handler.Slack.Token == "") && (os.Getenv("SLACK_TOKEN") != "") {
 		c.Handler.Slack.Token = os.Getenv("SLACK_TOKEN")
+	}
+}
+
+func (c *Config) UnmarshallConfig() {
+
+	// Resource Object Config add events under global scope
+	if c.Resource != (Resource{}) {
+		logrus.Info("Configuring Resources For Global Events")
+		if c.Resource.DaemonSet {
+			c.Event.Global = append(c.Event.Global, "demonset")
+		}
+		if c.Resource.ReplicaSet {
+			c.Event.Global = append(c.Event.Global, "replicaset")
+		}
+		if c.Resource.Namespace {
+			c.Event.Global = append(c.Event.Global, "namespace")
+		}
+		if c.Resource.Deployment {
+			c.Event.Global = append(c.Event.Global, "deployment")
+		}
+		if c.Resource.Pod {
+			c.Event.Global = append(c.Event.Global, "pod")
+		}
+		if c.Resource.ReplicationController {
+			c.Event.Global = append(c.Event.Global, "replicationcontroller")
+		}
+		if c.Resource.Service {
+			c.Event.Global = append(c.Event.Global, "service")
+		}
+		if c.Resource.Job {
+			c.Event.Global = append(c.Event.Global, "job")
+		}
+		if c.Resource.PersistentVolume {
+			c.Event.Global = append(c.Event.Global, "persistentvolume")
+		}
+		if c.Resource.Secret {
+			c.Event.Global = append(c.Event.Global, "secret")
+		}
+		if c.Resource.ConfigMap {
+			c.Event.Global = append(c.Event.Global, "configmap")
+		}
+		if c.Resource.Ingress {
+			c.Event.Global = append(c.Event.Global, "ingress")
+		}
+	} else {
+		// Configured using Events Config
+		logrus.Info("Configuring Resources Based on Events Config")
+		c.configureEvents(c.Event.Global)
+		c.configureEvents(c.Event.Create)
+		c.configureEvents(c.Event.Update)
+		c.configureEvents(c.Event.Delete)
+	}
+}
+
+func (c *Config) configureEvents(s []string) {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case "deployment":
+			{
+				c.Resource.Deployment = true
+			}
+		case "replicationcontroller":
+			{
+				c.Resource.ReplicationController = true
+			}
+		case "replicaset":
+			{
+				c.Resource.ReplicaSet = true
+			}
+		case "daemonset":
+			{
+				c.Resource.DaemonSet = true
+			}
+		case "service":
+			{
+				c.Resource.Service = true
+			}
+		case "pod":
+			{
+				c.Resource.Pod = true
+			}
+		case "job":
+			{
+				c.Resource.Job = true
+			}
+		case "persistentvolume":
+			{
+				c.Resource.PersistentVolume = true
+			}
+		case "namespace":
+			{
+				c.Resource.Namespace = true
+			}
+		case "secret":
+			{
+				c.Resource.Secret = true
+			}
+		case "configmap":
+			{
+				c.Resource.ConfigMap = true
+			}
+		case "ingress":
+			{
+				c.Resource.Ingress = true
+			}
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,7 +39,7 @@ var configStr = `
     	"replicationcontroller": "false",
     	"replicaset": "false",
     	"daemonset": "false",
-    	"services": "false",
+    	"Service": "false",
     	"pod": "false",
     	"secret": "true",
     	"configmap": "true",

--- a/examples/conf/kubewatch.conf.events.yaml
+++ b/examples/conf/kubewatch.conf.events.yaml
@@ -1,0 +1,15 @@
+handler:
+  flock:
+    url: "https://api.flock.com/hooks/sendMessage/XXXXXXXX" # XXXXXXXX to be replaced with incomming webhooks of the flock channl
+event:
+    global:
+     - pod
+     - deployment
+    create:
+     - service
+    update:
+    delete:
+     - job
+     - service
+namespace: ""
+


### PR DESCRIPTION
This commit

- Adds "Event" config section in the .kubewatch.yaml file for granular alerting
- Makes Event config optional
- Makes Resource config optional for backward compatibility
- Enables configuration of alerts either using the "Resource" config or "Event" Config
- Renames "Services" option to "Service" option in .kubewatch.yaml file
- Populates Namespace details from events key, if the Namespace filed is empty

Upon Merging

- Enables the user to customize alerts based on the Event configuration provided.
  eg: pod - alerts on creation and deletion events can be configured.
      svc - alerts on deletion can be configured individually.